### PR TITLE
Add readonly options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Incognito Field v. 1.0.0 for Craft CMS ![Craft 2.5](https://img.shields.io/badge/craft-2.5-red.svg?style=flat-square)
 
-**PlainText drop-in replacement, with the ability to be set as `disabled` or `hidden`**  
+**PlainText drop-in replacement, with the ability to be set as `disabled` or `hidden` or `readonly`**  
 
 ## What?
 
-Incognito Field adds a custom FieldType to Craft CMS, called _Incognito_. Incognito fields work exactly like regular PlainText fields, except that they can be configured to be disabled or hidden for element editor forms.  
+Incognito Field adds a custom FieldType to Craft CMS, called _Incognito_. Incognito fields work exactly like regular PlainText fields, except that they can be configured to be disabled, readonly or hidden for element editor forms.  
 
 An example use case for Incognito fields is whenever you need a field that shouldn't be editable via the CP – e.g. if you want to save some data from a feed or external API on your element model.  
 
@@ -18,7 +18,7 @@ Incognito Field works both standalone and inside Matrix blocks.
 
 ## Usage
 
-Incognito Field works exactly like the vanilla PlainText field, but has an additional setting – _mode_. Set to "disabled" for a disabled `text` input or `textarea`, or "hidden" to completely hide the field.  
+Incognito Field works exactly like the vanilla PlainText field, but has an additional setting – _mode_. Set to "disabled" for a disabled `text` input or `textarea`, "readonly" if you want a more legible readonly field where you can still select the text, or "hidden" to completely hide the field.  
 
 Please see the official docs for the [PlainText FieldType](https://craftcms.com/docs/plain-text-fields) for more information.  
 
@@ -31,6 +31,10 @@ Please report any bugs, feature requests or other issues [here](https://github.c
 **Pull requests are extremely welcome**  
 
 ### Changelog
+
+#### 1.0.1 (05.13.2016)
+
+* Added readonly option
 
 #### 1.0.0 (03.11.2016)
 

--- a/incognitofield/IncognitoFieldPlugin.php
+++ b/incognitofield/IncognitoFieldPlugin.php
@@ -93,7 +93,7 @@ class IncognitoFieldPlugin extends BasePlugin
      */
     public function getVersion()
     {
-        return '1.0.0';
+        return '1.0.1';
     }
 
     /**

--- a/incognitofield/templates/input.twig
+++ b/incognitofield/templates/input.twig
@@ -16,6 +16,7 @@
 
 {% set isHidden = settings.mode == 'hidden' %}
 {% set isDisabled = settings.mode == 'disabled' %}
+{% set isReadOnly = settings.mode == 'readonly' %}
 
 {% if isHidden %}
 <style>
@@ -43,4 +44,14 @@
 	{{ _forms.hidden(config) }}
 {% else %}
 	{{ _forms.text(config) }}
+{% endif %}
+
+{% if isReadOnly %}
+    <script>
+        var temp = document.getElementById("{{ id }}");
+        temp.setAttribute("readonly", "readonly");
+        temp.style.background = "rgb(250,250,250)";
+        temp.style.boxShadow = "none";
+        temp.style.opacity = '0.8';
+    </script>
 {% endif %}

--- a/incognitofield/templates/settings.twig
+++ b/incognitofield/templates/settings.twig
@@ -11,6 +11,7 @@
 		options : {
 			'plain' : 'Default'|t,
 			'disabled' : 'Disabled'|t,
+			'readonly' : 'Read Only'|t,
 			'hidden' : 'Hidden'|t
 		}
 	}) -}}

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,13 @@
 [
     {
+        "version": "1.0.1",
+        "downloadUrl": "https://github.com/mmikkel/IncognitoField-Craft/archive/master.zip",
+        "date": "2016-05-13T15:57:58+10:00",
+        "notes": [
+            "[Added] Read Only option (similar to disabled but more legible and you can select the text still)"
+        ]
+    }
+    {
         "version": "1.0.0",
         "downloadUrl": "https://github.com/mmikkel/IncognitoField-Craft/archive/master.zip",
         "date": "2016-03-11T07:54:39.322Z",


### PR DESCRIPTION
Hi

This field is great, but I need to still be able to select the text in my 'dsabled' field, so I've added a readonly option.  I also needed this text to be more visible, so I've styled it accordingly.

Because readonly is an attribute, not a style, I had to use some simple JS to do this.  Hope that is ok!

![2016-05-13_16-02-03](https://cloud.githubusercontent.com/assets/731309/15239244/3e4f45b2-1924-11e6-873e-98f1511397e6.png)
